### PR TITLE
Avoid marking a string as .html_safe unless you are sure

### DIFF
--- a/lib/bh/classes/alert_box.rb
+++ b/lib/bh/classes/alert_box.rb
@@ -12,7 +12,7 @@ module Bh
       def dismissible_button
         if @options[:dismissible] || @options[:priority]
           path = '../../views/bh/_alert_dismiss_button.html'
-          File.read File.expand_path(path, __FILE__)
+          File.read(File.expand_path(path, __FILE__)).html_safe
         end
       end
 

--- a/lib/bh/classes/base.rb
+++ b/lib/bh/classes/base.rb
@@ -82,7 +82,7 @@ module Bh
         ''.html_safe.tap do |str|
           array.compact.each_with_index do |elem, i|
             str << delimiter if i > 0
-            str << elem
+            str << elem.to_s
           end
         end
       end

--- a/lib/bh/classes/base.rb
+++ b/lib/bh/classes/base.rb
@@ -44,7 +44,7 @@ module Bh
         file = File.expand_path "../../views/bh/_#{partial}.html.erb", __FILE__
         template = ERB.new(File.read file)
         assigns = OpenStruct.new attributes.merge(content: @content)
-        render template.result(assigns.instance_eval{ binding &nil }).html_safe
+        render template.result(assigns.instance_eval{ binding &nil })
       end
 
       def tag
@@ -59,7 +59,7 @@ module Bh
         items = Array.wrap(@content).map do |item|
           item.is_a?(Base) ? item.content_tag(item.tag) : item
         end
-        items.all?(&:html_safe?) ? safe_join(items) : items.join
+        safe_join(items)
       end
 
       def content_tag(tag)
@@ -78,8 +78,13 @@ module Bh
 
     private
 
-      def safe_join(array = [])
-        array.compact.join("\n").html_safe
+      def safe_join(array = [], delimiter = "\n")
+        ''.html_safe.tap do |str|
+          array.compact.each_with_index do |elem, i|
+            str << delimiter if i > 0
+            str << elem
+          end
+        end
       end
 
       def stack(&block)


### PR DESCRIPTION
i.e., only for cases where string is constant
- Also fixes a subtle bug involving safe_join([helper_object]), where
  helper_object.html_safe? may not be defined or may not return true
  but helper_object.to_s.html_safe? returns true
  e.g., https://github.com/Angelmmiguel/material_icons
  bh escapes the html instead of displaying icon today 
